### PR TITLE
[FIX] Issue Beet deleted twice

### DIFF
--- a/1.2/Source/VanillaPlantsExpanded/VanillaPlantsExpanded/Patches/Plant_PlantCollected.cs
+++ b/1.2/Source/VanillaPlantsExpanded/VanillaPlantsExpanded/Patches/Plant_PlantCollected.cs
@@ -1,11 +1,6 @@
 ﻿using HarmonyLib;
 using RimWorld;
-using System.Reflection;
 using Verse;
-using System.Collections.Generic;
-using RimWorld.Planet;
-using System.Linq;
-using System;
 
 namespace VanillaPlantsExpanded
 {
@@ -14,13 +9,19 @@ namespace VanillaPlantsExpanded
     public static class VanillaCookingExpanded_Plant_PlantCollected_Patch
     {
         [HarmonyPrefix]
-        public static void RemoveTilled(ref Plant __instance)
-        {           
-                if (__instance.Map.terrainGrid.TerrainAt(__instance.Position).defName == "VCE_TilledSoil"){
-                    if (__instance.IsCrop) {
-                    __instance.Map.terrainGrid.RemoveTopLayer(__instance.Position);
-                    }                    
+        public static void AccessMap(Plant __instance, out Map __state)
+        {
+            __state = __instance.Map;
+        }
+
+        [HarmonyPostfix]
+        public static void RemoveTilled(Plant __instance, Map __state)
+        {
+            if (__state.terrainGrid.TerrainAt(__instance.Position).defName == "VCE_TilledSoil") {
+                if (__instance.def.plant.HarvestDestroys) {
+                    __state.terrainGrid.RemoveTopLayer(__instance.Position);
                 }
+            }
         }
     }
 }


### PR DESCRIPTION
 - utilizing Harmony __state to access map
 - deleting tilled soil in postfix after deleting the plant

That fixes the issue (only shown if you are in development mode) of the beet root deleted twice cause the terrain is deleted earlier.