### PR TITLE
Fix tomatoes not being regarded as tasty raw (causing negative ate raw food thought) by colonists

### DIFF
--- a/1.3/Defs/ThingDefs_Items/Items_Resource_RawPlant.xml
+++ b/1.3/Defs/ThingDefs_Items/Items_Resource_RawPlant.xml
@@ -223,6 +223,7 @@
 		<ingestible>
 			<foodType>VegetableOrFruit</foodType>
 			<preferability>RawTasty</preferability>
+			<tasteThought></tasteThought>
 		</ingestible>    
 	</ThingDef>
 	


### PR DESCRIPTION
Turns out you need to manually set a null tasteThought in addition to
RawTasty -- see core RawBerries def.